### PR TITLE
Bump to 0.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "statuspage" %}
-{% set version = "0.7.0" %}
+{% set version = "0.8.0" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 354099766678b001a09b9950849acac23152aa4a4bc0f7e62949ca9df4dd331f
+  sha256: 4b1f50967167ecdc90332870667ce7e299919a7bbd9df3209f6563418202f341
 
 build:
   number: 0


### PR DESCRIPTION
``` markdown
## 0.8.0 [2016-09-2]
- Added client side translation.
- Added german translation.
- It's now possible to add/remove systems from the CLI.
```
