### PR TITLE
Bump to 0.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "statuspage" %}
-{% set version = "0.8.0" %}
+{% set version = "0.8.1" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4b1f50967167ecdc90332870667ce7e299919a7bbd9df3209f6563418202f341
+  sha256: 4eb5f3bc2ea33f59f0b42c9cd2ef6c909e09069b7c96a71dae32f72dab068b02
 
 build:
   number: 0
@@ -38,6 +38,7 @@ test:
 about:
   home: https://github.com/jayfk/statuspage
   license: MIT
+  license_file: LICENSE
   license_family: MIT
   summary: A statuspage generator that lets you host your statuspage for free on Github.
 


### PR DESCRIPTION
``` markdown
## 0.8.1 [2016-09-6]
- Fixed a silly encoding error on legacy python
```
